### PR TITLE
Update GitHub workflow permissions for preview and production environments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,10 +8,7 @@ on:
     push:
         branches-ignore:
             - master
-permissions:
-    contents: read
-    pull-requests: write
-    issues: write
+    workflow_dispatch: {}
 jobs:
     Deploy-Preview:
         runs-on: ubuntu-latest

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -8,10 +8,7 @@ on:
     push:
         branches:
             - master
-permissions:
-    contents: read
-    pull-requests: write
-    issues: write
+    workflow_dispatch: {}
 jobs:
     Deploy-Production:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub workflow permissions for the preview and production environments. The permissions for contents, pull requests, and issues have been modified to allow read access. The changes ensure that the workflow_dispatch event is triggered for both branches and that the jobs run on the ubuntu-latest environment.