### PR TITLE
Update allowed hostnames in RequestValidator

### DIFF
--- a/app/lib.ts
+++ b/app/lib.ts
@@ -36,6 +36,7 @@ class RceEngine {
 
 class RequestValidator {
     private static readonly ALLOWED_HOSTNAMES: ReadonlySet<string> = new Set([
+        'www.codespacex.com',
         'codespacex.com',
         'carai-eight.vercel.app',
         'localhost',


### PR DESCRIPTION
This pull request updates the list of allowed hostnames in the `RequestValidator` class. The hostname "www.codespacex.com" has been added to the list.