### PR TITLE
Fix dark mode text color

### DIFF
--- a/components/ui/unsupported-device.tsx
+++ b/components/ui/unsupported-device.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 const UnsupportedDevice: FC = () => {
     return (
         <div className="flex min-h-dvh items-center justify-center p-5">
-            <div className="prose prose-base w-full max-w-lg flex-1">
+            <div className="prose prose-base w-full max-w-lg flex-1 dark:prose-invert">
                 <h1 className="mb-4">Unsupported Device</h1>
                 <p className="mb-3">
                     It looks like you&apos;re using a device that may not


### PR DESCRIPTION
This pull request fixes the text color in dark mode for the "Unsupported Device" component. Previously, the text color was not being inverted correctly, causing readability issues. With this fix, the text color will now be properly inverted in dark mode, ensuring better readability for users.