### PR TITLE
Add device-based restriction

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,4 +1,4 @@
-import { type NextRequest, NextResponse } from 'next/server'
+import { type NextRequest, NextResponse, userAgent } from 'next/server'
 import { Ratelimit } from '@upstash/ratelimit'
 import { kv } from '@vercel/kv'
 
@@ -16,6 +16,14 @@ export const config = {
 export default async function middleware(request: NextRequest) {
     const ip = new RequestValidator(request).requestIp
     const { success } = await ratelimit.limit(ip)
+    const { device } = userAgent(request)
+
+    if (device.type === 'mobile' || device.type === undefined) {
+        return NextResponse.json(
+            { success: false, message: 'Device not supported' },
+            { status: 403 }
+        )
+    }
 
     return success
         ? NextResponse.next()

--- a/hooks/useDeviceSupportCheck.tsx
+++ b/hooks/useDeviceSupportCheck.tsx
@@ -18,7 +18,15 @@ const useDeviceSupportCheck = () => {
     const checkScreenSize = useCallback(() => {
         const deviceWidth = window.innerWidth
 
-        const supportedDevice = deviceWidth >= SUPPORTED_DEVICE_WIDTH
+        const supportedDeviceWidth = deviceWidth >= SUPPORTED_DEVICE_WIDTH
+
+        const userAgent = navigator.userAgent.toLowerCase()
+        const isMobileDevice =
+            /iphone|ipod|android.*mobile|blackberry|mini|windows\sce|palm/i.test(
+                userAgent
+            )
+
+        const supportedDevice = supportedDeviceWidth && !isMobileDevice
 
         setIsSupported(supportedDevice)
     }, [])


### PR DESCRIPTION
This pull request adds a device-based restriction to the middleware and the useDeviceSupportCheck hook. The middleware now checks the user agent to determine if the device is supported. If the device is a mobile device or if the device type is undefined, a 403 Forbidden response is returned. The useDeviceSupportCheck hook now also checks the user agent to determine if the device is supported. If the device width is less than the supported device width and the user agent indicates a mobile device, the hook sets the isSupported state to false.