### PR TITLE
Refactor transformString function to accept an object parameter

### DIFF
--- a/components/ui/monaco-editor.tsx
+++ b/components/ui/monaco-editor.tsx
@@ -85,11 +85,11 @@ const MonacoEditor: FC<EditorProps> = ({ className, ...props }) => {
     return (
         <_Editor
             className={className}
-            language={transformString(
-                activeTab.metadata.languageName,
-                languageSupportTransformMap,
-                { lowerCase: true }
-            )}
+            language={transformString({
+                str: activeTab.metadata.languageName,
+                map: languageSupportTransformMap,
+                lowerCase: true,
+            })}
             loading={<SplashScreen />}
             options={editorConfigOptions}
             theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs-light'}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -286,13 +286,11 @@ const Sidebar: FC = () => {
                                                     width={100}
                                                 />
                                                 <span className="text-nowrap">
-                                                    {transformString(
-                                                        runtime.languageName,
-                                                        languageNameTransformMap,
-                                                        {
-                                                            capitalize: true,
-                                                        }
-                                                    )}
+                                                    {transformString({
+                                                        str: runtime.languageName,
+                                                        map: languageNameTransformMap,
+                                                        capitalize: true,
+                                                    })}
                                                 </span>
                                             </Label>
                                         </div>

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -74,11 +74,11 @@ const Tabs: FC = () => {
         const { id, metadata, content, filename } = activeTab
         const start = Date.now()
         const lowerCaseLanguageName = metadata.languageName.toLowerCase()
-        const toImageName = transformString(
-            lowerCaseLanguageName,
-            imageNameTransformMap,
-            { lowerCase: true }
-        )
+        const toImageName = transformString({
+            str: lowerCaseLanguageName,
+            map: imageNameTransformMap,
+            lowerCase: true,
+        })
         const image = `toolkithub/${toImageName}:edge`
 
         return new Promise<CodeResponse>((resolve, reject) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -69,19 +69,20 @@ type Into = Partial<{
     lowerCase: boolean
 }>
 
-function transformString(
-    str: string,
-    map: Record<string, string>,
-    into: Into = {
-        capitalize: false,
-        lowerCase: false,
-    }
-): string {
+function transformString({
+    str,
+    map,
+    capitalize,
+    lowerCase,
+}: {
+    str: string
+    map: Record<string, string>
+} & Into): string {
     const transform = map[str] || str
 
-    return into.capitalize
+    return capitalize
         ? capitalizeFirstLetter(transform)
-        : into.lowerCase
+        : lowerCase
           ? transform.toLowerCase()
           : transform
 }


### PR DESCRIPTION
This pull request refactors the `transformString` function to accept an object parameter instead of multiple individual parameters. This improves the readability and maintainability of the code by consolidating the function arguments into a single object.