### PR TITLE
Update GITHUB_TOKEN in production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -46,4 +46,6 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          working_directory: ./web


### PR DESCRIPTION
This PR updates the GITHUB_TOKEN environment variable in the production workflow to use the correct secret name. Previously, it was using GH_TOKEN, which caused a CI error. The correct secret name is now GITHUB_TOKEN, ensuring that the workflow can access the necessary credentials for the deployment process.