### PR TITLE
Refactor CI workflows to include deployments permission

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   packages: write
+  deployments: write
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -48,6 +49,13 @@ jobs:
 
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+  Release:
+    runs-on: ubuntu-latest
+    needs: Deploy-Production
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
This pull request refactors the CI workflows to include the necessary deployments permission. This allows for the deployment of project artifacts to Vercel and enables the use of semantic release.