### PR TITLE
Fix missing package.json file

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -62,3 +62,4 @@ jobs:
           extra_plugins: |
             @semantic-release/git
             @semantic-release/changelog
+          working_directory: ./web


### PR DESCRIPTION
This pull request fixes the issue of a missing `package.json` file. The `working_directory` has been updated to point to the `./web` directory. This ensures that the `package.json` file is included in the repository.